### PR TITLE
Add remaining authz-supporting networks

### DIFF
--- a/stakin/chains.json
+++ b/stakin/chains.json
@@ -3,19 +3,64 @@
   "name": "Stakin",
   "chains": [
     {
-      "name": "juno",
-      "address": "junovaloper1xdywquvz5g6r5wv6tpkj6chad0fkk459gf9ny6",
+      "name": "agoric",
+      "address": "agoricvaloper1nkrt7kjln9rsypg3m4k23q703nww9lj9msvqp5",
       "restake": {
-        "address": "juno1yq67lj5nnkcc2jk9ngfe3v6mt5ra0n9d3sj4sk",
+        "address": "agoric1yq67lj5nnkcc2jk9ngfe3v6mt5ra0n9d4ln38u",
         "run_time": "every 1 hour",
         "minimum_reward": 100000
       }
     },
     {
-      "name": "umee",
-      "address": "umeevaloper10nsytn9zmtfnhk37hqfe2h9v599ld3h5zs9fqj",
+      "name": "akash",
+      "address": "akashvaloper12fnzqmnja37mf2y9m6r3dleq5n3jkz7pfkpzmy",
       "restake": {
-        "address": "umee1yq67lj5nnkcc2jk9ngfe3v6mt5ra0n9d45v3nc",
+        "address": "akash1yq67lj5nnkcc2jk9ngfe3v6mt5ra0n9d2eufws",
+        "run_time": "every 1 hour",
+        "minimum_reward": 100000
+      }
+    },
+    {
+      "name": "comdex",
+      "address": "comdexvaloper1g6zz4d7j6fvxy24nsqkjrcxqrt7hwp6p6hws7c",
+      "restake": {
+        "address": "comdex1yq67lj5nnkcc2jk9ngfe3v6mt5ra0n9dqdnvwa",
+        "run_time": "every 1 hour",
+        "minimum_reward": 100000
+      }
+    },
+    {
+      "name": "cosmoshub",
+      "address": "cosmosvaloper1fhr7e04ct0zslmkzqt9smakg3sxrdve6ulclj2",
+      "restake": {
+        "address": "cosmos1yq67lj5nnkcc2jk9ngfe3v6mt5ra0n9d8z3wh2",
+        "run_time": "every 1 hour",
+        "minimum_reward": 100000
+      }
+    },
+    {
+      "name": "crescent",
+      "address": "crevaloper126nxgyruw03fyr3rmxg76squcy08pjtm9zkl5d",
+      "restake": {
+        "address": "cre1yq67lj5nnkcc2jk9ngfe3v6mt5ra0n9dr2ztz8",
+        "run_time": "every 1 hour",
+        "minimum_reward": 100000
+      }
+    },
+    {
+      "name": "cryptoorgchain",
+      "address": "crocncl18nc2zx5rs7jwm7dwk5gvelul2wer8zfykfmg8h",
+      "restake": {
+        "address": "cro1yq67lj5nnkcc2jk9ngfe3v6mt5ra0n9dleehtm",
+        "run_time": "every 1 hour",
+        "minimum_reward": 100000
+      }
+    },
+    {
+      "name": "desmos",
+      "address": "desmosvaloper1567u3n4q6j0zm5mkgtqu9t7eq4g5pr5se74mr9",
+      "restake": {
+        "address": "desmos1yq67lj5nnkcc2jk9ngfe3v6mt5ra0n9dn6u7qj",
         "run_time": "every 1 hour",
         "minimum_reward": 100000
       }
@@ -27,6 +72,96 @@
         "address": "evmos1rddqmf6y36geq90daesm057uaagasjd0rr925z",
         "run_time": "every 1 hour",
         "minimum_reward": 100000000000000000
+      }
+    },
+    {
+      "name": "gravitybridge",
+      "address": "gravityvaloper1haznywsf8l60xftvkgl79dstyuw3vw5x0v7kgn",
+      "restake": {
+        "address": "gravity1yq67lj5nnkcc2jk9ngfe3v6mt5ra0n9drjrkjz",
+        "run_time": "every 1 hour",
+        "minimum_reward": 100000
+      }
+    },
+    {
+      "name": "juno",
+      "address": "junovaloper1xdywquvz5g6r5wv6tpkj6chad0fkk459gf9ny6",
+      "restake": {
+        "address": "juno1yq67lj5nnkcc2jk9ngfe3v6mt5ra0n9d3sj4sk",
+        "run_time": "every 1 hour",
+        "minimum_reward": 100000
+      }
+    },
+    {
+      "name": "kava",
+      "address": "kavavaloper1dede4flaq24j2g9u8f83vkqrqxe6cwzrxt5zsu",
+      "restake": {
+        "address": "kava1yq67lj5nnkcc2jk9ngfe3v6mt5ra0n9dmh9npd",
+        "run_time": "every 1 hour",
+        "minimum_reward": 100000
+      }
+    },
+    {
+      "name": "persistence",
+      "address": "persistencevaloper1xykmyvzk88qrlqh3wuw4jckewleyygupsumyj5",
+      "restake": {
+        "address": "persistence1yq67lj5nnkcc2jk9ngfe3v6mt5ra0n9dfwhaew",
+        "run_time": "every 1 hour",
+        "minimum_reward": 100000
+      }
+    },
+    {
+      "name": "regen",
+      "address": "regenvaloper16dxk5trv9nz7jnpyvz48ngve45an4hkqkuafza",
+      "restake": {
+        "address": "regen1yq67lj5nnkcc2jk9ngfe3v6mt5ra0n9dcq6jpw",
+        "run_time": "every 1 hour",
+        "minimum_reward": 100000
+      }
+    },
+    {
+      "name": "sentinel",
+      "address": "sentvaloper13gmgxsxdvmytnr75uscuw350n6f0qfrvgdacw4",
+      "restake": {
+        "address": "sent1yq67lj5nnkcc2jk9ngfe3v6mt5ra0n9due8hn9",
+        "run_time": "every 1 hour",
+        "minimum_reward": 100000
+      }
+    },
+    {
+      "name": "stargaze",
+      "address": "starsvaloper1swer6tl0s59g82xnq5gmgsdueld79wpw8vptlu",
+      "restake": {
+        "address": "stars1yq67lj5nnkcc2jk9ngfe3v6mt5ra0n9dn7xnum",
+        "run_time": "every 1 hour",
+        "minimum_reward": 100000
+      }
+    },
+    {
+      "name": "terra",
+      "address": "terravaloper1nwrksgv2vuadma8ygs8rhwffu2ygk4j24w2mku",
+      "restake": {
+        "address": "terra1yq67lj5nnkcc2jk9ngfe3v6mt5ra0n9dpxtw42",
+        "run_time": "every 1 hour",
+        "minimum_reward": 100000
+      }
+    },
+    {
+      "name": "terra2",
+      "address": "terravaloper1mgpgp53tynj4djmckxdjhufa7q8lqqjuwnrlqm",
+      "restake": {
+        "address": "terra1yq67lj5nnkcc2jk9ngfe3v6mt5ra0n9dpxtw42",
+        "run_time": "every 1 hour",
+        "minimum_reward": 100000
+      }
+    },
+    {
+      "name": "umee",
+      "address": "umeevaloper10nsytn9zmtfnhk37hqfe2h9v599ld3h5zs9fqj",
+      "restake": {
+        "address": "umee1yq67lj5nnkcc2jk9ngfe3v6mt5ra0n9d45v3nc",
+        "run_time": "every 1 hour",
+        "minimum_reward": 100000
       }
     }
   ]


### PR DESCRIPTION
Here we are including the remaining 15 networks that we run and which support Authz. After merging this to upstream registry we will be eligible REStake operators on restake.app.